### PR TITLE
Microclimate

### DIFF
--- a/daisy/daisy_world_rl.py
+++ b/daisy/daisy_world_rl.py
@@ -26,13 +26,20 @@ class RLDaisyWorld():
         # Stefan-Boltzmann constant
         self.sigma = 5.67e-8
         self.gamma = 0.25
-        # starvation/food depletion for agents
-        self.agent_gamma = 0.05
         self.q = 0.2 * self.S / self.sigma
-        self.q2 = self.q / 8.
+        self.use_microclimate = True
+
+        if self.use_microclimate:
+            self.q2 = self.q / 8.
+        else:
+            self.q2 = 0.0
+
         self.Toptim = 295.5
         self.dt = 0.05
         self.ddL = 0.
+        # starvation/food depletion for agents
+        self.agent_gamma = 0.05
+        
         
         # stellar luminosity R[0.,2.]
         self.max_L = 1.5
@@ -59,6 +66,14 @@ class RLDaisyWorld():
         self.initialize_agents()
         self.reset()
 
+    def set_use_microclimate(self, use_microclimate=True):
+
+        self.use_microclimate = use_microclimate
+
+        if self.use_microclimate:
+            self.q2 = self.q / 8.
+        else:
+            self.q2 = 0.0
 
     def make_config(self):
 

--- a/notebooks/rl_daisy_world.ipynb
+++ b/notebooks/rl_daisy_world.ipynb
@@ -285,16 +285,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3b93cc86",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "env.dt"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "83248d6e",
    "metadata": {},
@@ -375,7 +365,6 @@
     "save_video = False #True\n",
     "\n",
     "env = RLDaisyWorld()\n",
-    "env.dim = 8\n",
     "env.albedo_dark = env.albedo_bare\n",
     "env.albedo_light = env.albedo_bare\n",
     "env.reset()\n",
@@ -435,13 +424,7 @@
     "\n",
     "env = RLDaisyWorld()\n",
     "env.batch_size = 1\n",
-    "env.dim = 8\n",
-    "\n",
-    "#env.max_L = 1.2\n",
-    "#env.min_L = 0.7\n",
-    "#env.ramp_period = 512\n",
     "env.n_agents = 1\n",
-    "\n",
     "obs = env.reset()\n",
     "\n",
     "interval = 50\n",


### PR DESCRIPTION
This change adds the addition of microclimates. Namely, in addition to the neighborhood and cell-level temperatures, an extra step calculates additional temperature for each species of daisy, _i.e._ microclimates. The growth coefficients `beta` are calculated from the microclimate temperatures for each daisy species. The microclimate temperature are calculated with a second flux variable `q2` which is a fraction of the neighborhood flux variable `q`

The effect of these changes is that selection no longer operates solely on the ratio of light to dark daisies in a given pixel/cell. This in turn facilitates a greater degree of environmental regulation. With selection at the level of light:dark ratios per pixel, a dominant ratio typically fills the grid as other ratios die out, for example a darker combination dominates the landscape and there is no reservoir of lighter ratios available to select from as temperatures increase. 

The changes yield behavior that more closely reflects the original 1983 model. 