### PR TITLE
update input dimensions for mlp agent

### DIFF
--- a/daisy/agents/mlp.py
+++ b/daisy/agents/mlp.py
@@ -12,7 +12,7 @@ from daisy.nn.functional import glorot
 class MLP():
     def __init__(self, **kwargs):
 
-        self.in_dim = 45
+        self.in_dim = 63 #45
         self.out_dim = 9
         self.h_dim = [16, 32]
 


### PR DESCRIPTION
This can be considered a finishing touch to PR #15 

MLP input dimensions were not updated to reflect the 7 channel daisyworld (2 extra channels for microclimate temperatures).

This PR adds them. 